### PR TITLE
fix: txt files not properly recognized as attachments

### DIFF
--- a/lib/src/Conjoon/Horde/Mail/Client/Imap/HordeClient.php
+++ b/lib/src/Conjoon/Horde/Mail/Client/Imap/HordeClient.php
@@ -1215,7 +1215,10 @@ class HordeClient implements MailClient
             $ret["hasAttachments"] = false;
             foreach ($typeMap as $part => $type) {
                 if (
-                    in_array($type, ["text/plain", "text/html"]) === false &&
+                    /**
+                     * @see conjoon/php-ms-imapuser#48
+                     */
+                    //in_array($type, ["text/plain", "text/html"]) === false &&
                     $messageStructure->getPart($part)->isAttachment()
                 ) {
                     $ret["hasAttachments"] = true;

--- a/lib/tests/Conjoon/Horde/Mail/Client/Imap/HordeClientTest.php
+++ b/lib/tests/Conjoon/Horde/Mail/Client/Imap/HordeClientTest.php
@@ -440,6 +440,7 @@ class HordeClientTest extends TestCase
 
 
         $attach = new Horde_Mime_Part();
+        $attach->setType("text/plain");
         $attach->setDisposition("attachment");
         $fetchResults[16]->setStructure($attach);
 


### PR DESCRIPTION
happened when content-type is multipart/mixed and content-type of attachment is
text/plain or text/html

refs conjoon/php-ms-imapuser#48